### PR TITLE
fallback to rootUri if workspaceFolders isn't set

### DIFF
--- a/src/main/java/SouffleLanguageServer.java
+++ b/src/main/java/SouffleLanguageServer.java
@@ -94,6 +94,7 @@ public class SouffleLanguageServer implements LanguageServer, LanguageClientAwar
         if(workspaceFolders != null && !workspaceFolders.isEmpty()){
             directory = URI.create(workspaceFolders.get(0).getUri()).getPath();
         } else {
+            // rootUri is deprecated. Here it's only used as a fallback if the client doesn't send any workspaceFolders
             directory = URI.create(initializeParams.getRootUri()).getPath();
         }
         if(directory != null) {

--- a/src/main/java/SouffleLanguageServer.java
+++ b/src/main/java/SouffleLanguageServer.java
@@ -89,9 +89,14 @@ public class SouffleLanguageServer implements LanguageServer, LanguageClientAwar
         }
 //        CompletableFuture.
         projectContext = SouffleProjectContext.getInstance();
+        String directory = null;
         List<WorkspaceFolder> workspaceFolders = initializeParams.getWorkspaceFolders();
         if(workspaceFolders != null && !workspaceFolders.isEmpty()){
-            String directory = URI.create(workspaceFolders.get(0).getUri()).getPath();
+            directory = URI.create(workspaceFolders.get(0).getUri()).getPath();
+        } else {
+            directory = URI.create(initializeParams.getRootUri()).getPath();
+        }
+        if(directory != null) {
             projectContext.setProjectPath(directory);
             traverseWorkspace(directory);
         }


### PR DESCRIPTION
Hi, this fixes the server not traversing the workspace folder when it's launched by lsp-mode (Emacs)

lsp-mode doesn't set workspaceFolders when it initializes the server. It may expect the server to request it to the client or it may send a notification after initialization but didn't debug that far. Probably related to this [behaviour](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#workspace_workspaceFolders).

This patch makes the server fall back to rootUri if workspaceFolders isn't set. I'm unfamiliar with the LSP protocol and this is only the fruit of some quick debugging so please let me know if this isn't the right approach.